### PR TITLE
Prevent Invalid Python module names from creating broken builds

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,13 @@
+import re
+import sys
+
+
+MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
+
+app_name = '{{ cookiecutter.app_name }}'
+
+if not re.match(MODULE_REGEX, app_name):
+    print('ERROR: `%s` is not a valid Python module name!' % app_name)
+
+    # exits with status 1 to indicate failure
+    sys.exit(1)


### PR DESCRIPTION
Raises Error on invalid Python module names

Resolves #2