### PR TITLE
Option to use PySide2

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,6 +17,7 @@
     ],
     "gui_framework": [
         "Toga",
+        "PySide2",
         "None"
     ]
 }

--- a/{{ cookiecutter.app_name }}/setup.py
+++ b/{{ cookiecutter.app_name }}/setup.py
@@ -47,17 +47,20 @@ setup(
         # Desktop/laptop deployments
         'macos': {
             'app_requires': [{% if cookiecutter.gui_framework == 'Toga' %}
-                'toga-cocoa==0.3.0.dev11',{% endif %}
+                'toga-cocoa==0.3.0.dev11',{% elif cookiecutter.gui_framework == 'PySide2' %}
+                'pyside2==5.13.0',{% endif %}
             ]
         },
         'linux': {
             'app_requires': [{% if cookiecutter.gui_framework == 'Toga' %}
-                'toga-gtk==0.3.0.dev11',{% endif %}
+                'toga-gtk==0.3.0.dev11',{% elif cookiecutter.gui_framework == 'PySide2' %}
+                'pyside2==5.13.0',{% endif %}
             ]
         },
         'windows': {
             'app_requires': [{% if cookiecutter.gui_framework == 'Toga' %}
-                'toga-winforms==0.3.0.dev11',{% endif %}
+                'toga-winforms==0.3.0.dev11',{% elif cookiecutter.gui_framework == 'PySide2' %}
+                'pyside2==5.13.0',{% endif %}
             ]
         },
 

--- a/{{ cookiecutter.app_name }}/setup.py
+++ b/{{ cookiecutter.app_name }}/setup.py
@@ -36,7 +36,8 @@ setup(
         'Development Status :: 1 - Planning',
         'License :: OSI Approved :: {{ cookiecutter.license }}',
     ],
-    install_requires=[
+    install_requires=[{% if cookiecutter.gui_framework == 'PySide2' %}
+        'pyside2==5.13.0',{% endif %}
     ],
     options={
         'app': {
@@ -47,20 +48,17 @@ setup(
         # Desktop/laptop deployments
         'macos': {
             'app_requires': [{% if cookiecutter.gui_framework == 'Toga' %}
-                'toga-cocoa==0.3.0.dev11',{% elif cookiecutter.gui_framework == 'PySide2' %}
-                'pyside2==5.13.0',{% endif %}
+                'toga-cocoa==0.3.0.dev11',{% endif %}
             ]
         },
         'linux': {
             'app_requires': [{% if cookiecutter.gui_framework == 'Toga' %}
-                'toga-gtk==0.3.0.dev11',{% elif cookiecutter.gui_framework == 'PySide2' %}
-                'pyside2==5.13.0',{% endif %}
+                'toga-gtk==0.3.0.dev11',{% endif %}
             ]
         },
         'windows': {
             'app_requires': [{% if cookiecutter.gui_framework == 'Toga' %}
-                'toga-winforms==0.3.0.dev11',{% elif cookiecutter.gui_framework == 'PySide2' %}
-                'pyside2==5.13.0',{% endif %}
+                'toga-winforms==0.3.0.dev11',{% endif %}
             ]
         },
 

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
@@ -3,6 +3,8 @@ from {{ cookiecutter.app_name }}.app import main
 if __name__ == '__main__':
 {%- if cookiecutter.gui_framework == 'Toga' %}
     main().main_loop()
+{%- if cookiecutter.gui_framework == 'PySide2' %}
+    main()
 {%- else %}
     main()
 {%- endif %}

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
@@ -3,7 +3,7 @@ from {{ cookiecutter.app_name }}.app import main
 if __name__ == '__main__':
 {%- if cookiecutter.gui_framework == 'Toga' %}
     main().main_loop()
-{%- if cookiecutter.gui_framework == 'PySide2' %}
+{%- elif cookiecutter.gui_framework == 'PySide2' %}
     main()
 {%- else %}
     main()

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
@@ -25,7 +25,7 @@ def main():
 from PySide2 import QtWidgets
 
 
-class MainWindow(QtWidgets.QMainWindow):
+class {{ app_class_name }}(QtWidgets.QMainWindow):
     def __init__(self):
         super().__init__()
         self.init_ui()
@@ -36,7 +36,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
 def main():
     app = QtWidgets.QApplication(sys.argv)
-    main_window = MainWindow()
+    main_window = {{ app_class_name }}()
     sys.exit(app.exec_())
 {% else -%}
 def main():

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
@@ -21,6 +21,23 @@ class {{ app_class_name }}(toga.App):
 
 def main():
     return {{ app_class_name }}('{{ cookiecutter.formal_name }}', '{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}')
+{% elif cookiecutter.gui_framework == 'PySide2' %}import sys
+from PySide2 import QtWidgets
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.init_ui()
+
+    def init_ui(self):
+        self.setWindowTitle('Hello World')
+        self.show()
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    main_window = MainWindow()
+    sys.exit(app.exec_())
 {% else -%}
 def main():
     # This should start and launch your app!

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
@@ -31,7 +31,7 @@ class {{ app_class_name }}(QtWidgets.QMainWindow):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowTitle('Hello World')
+        self.setWindowTitle('{{ cookiecutter.app_name }}')
         self.show()
 
 def main():


### PR DESCRIPTION
This adds the option to use PySide2 (instead of Toga).

I wasn't sure what to do with the iOS, Android and Django sections in `setup.py`, so I haven't made them require PySide2.

You can try this with `cookiecutter https://github.com/fredrikaverpil/briefcase-template`