### PR TITLE
Make app code follow clean coding

### DIFF
--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
@@ -1,3 +1,6 @@
+"""
+{{ cookiecutter.description }}
+"""
 {% set app_class_name = cookiecutter.formal_name.title().replace(' ','').replace('-','').replace('!','').replace('.','').replace(',','') -%}
 {% if cookiecutter.gui_framework == 'Toga' %}import toga
 from toga.style import Pack
@@ -5,17 +8,19 @@ from toga.style.pack import COLUMN, ROW
 
 
 class {{ app_class_name }}(toga.App):
-    def startup(self):
-        # Create a main window with a name matching the app
-        self.main_window = toga.MainWindow(title=self.name)
 
-        # Create a main content box
+    def startup(self):
+        """
+        Construct and show the Toga application.
+
+        Usually, you would add your application to a main content box.
+        We then create a main window (with a name matching the app), and
+        show the main window.
+        """
         main_box = toga.Box()
 
-        # Add the content on the main window
+        self.main_window = toga.MainWindow(title=self.name)
         self.main_window.content = main_box
-
-        # Show the main window
         self.main_window.show()
 
 


### PR DESCRIPTION
The changes in this PR attempt to make the app code more self-explanatory. Instead of comments we're using docstrings, functions do "only one thing", we clean up all unneeded code (unused imports). 

BeeWare users should be inspired by self-explanatory, clean code. The rest is in the documentation.

**Note:** After this is merged, the [related documentation](https://github.com/beeware/briefcase/blob/master/docs/tutorial/tutorial-0.rst) needs be aligned again, too.