### PR TITLE
Fix pyproject.toml formatting error

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -37,15 +37,15 @@ requires = [
     'toga-gtk>=0.3.0.dev18',
 {% endif -%}
 ]
-{%- if cookiecutter.gui_framework == 'Toga' %}
 system_requires = [
+{%- if cookiecutter.gui_framework == 'Toga' %}
     'libgirepository1.0-dev',
     'libcairo2-dev',
     'libpango1.0-dev',
     'libwebkitgtk-3.0-0',
     'gir1.2-webkit-3.0',
-]
 {% endif -%}
+]
 
 [tool.briefcase.app.{{ cookiecutter.app_name }}.windows]
 requires = [


### PR DESCRIPTION
The cookicutter template is gnerating a `pyproject.toml` file with two missing `\n` characters. There should be a line break before `[tool.briefcase.app.helloworld.windows]` in the generated file.

We can fix this by moving the cookiecutter tags inside the square brackets of our list.
(The cookiecutter tags seem "greedy" and appear to suck up extra whitespace around them.)

Closes https://github.com/beeware/briefcase/issues/405

### Before the fix:

```
{%- if cookiecutter.gui_framework == 'Toga' %}
system_requires = [
    'libgirepository1.0-dev',
    'libcairo2-dev',
    'libpango1.0-dev',
    'libwebkitgtk-3.0-0',
    'gir1.2-webkit-3.0',
]
{% endif -%}
```



Generates this in `pyproject.toml`
```
...
[tool.briefcase.app.helloworld.macOS]
requires = []

[tool.briefcase.app.helloworld.linux]
requires = [][tool.briefcase.app.helloworld.windows]
requires = []

# Mobile deployments
...
```

### After the fix:
The cookicutter tags have been moved inside the square brackets of the list.
```
system_requires = [
{%- if cookiecutter.gui_framework == 'Toga' %}
    'libgirepository1.0-dev',
    'libcairo2-dev',
    'libpango1.0-dev',
    'libwebkitgtk-3.0-0',
    'gir1.2-webkit-3.0',
{% endif -%}
]
```


Generates this correct `pyproject.toml`
```
[tool.briefcase.app.helloworld.macOS]
requires = []

[tool.briefcase.app.helloworld.linux]
requires = []
system_requires = []

[tool.briefcase.app.helloworld.windows]
requires = []

# Mobile deployments
```
