### PR TITLE
Include setuptools & wheel by default in pyproject.toml build-system

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -1,6 +1,3 @@
-[build-system]
-requires = ["briefcase", "setuptools", "wheel"]
-
 [tool.briefcase]
 project_name = "{{ cookiecutter.project_name }}"
 bundle = "{{ cookiecutter.bundle }}"

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["briefcase"]
+requires = ["briefcase", "setuptools", "wheel"]
 
 [tool.briefcase]
 project_name = "{{ cookiecutter.project_name }}"


### PR DESCRIPTION
I'd like to propose adding setuptools and wheel by default to the build-system specs in pyproject.toml.

Right now if you run the briefcase tutorial and then attempt to retro-fit it to an existing python project, you can find you are suddenly unable to pip install your project. This happened to me earlier, our project had an existing pyproject.toml (that didn't specify build-system). When I appended the briefcase pyproject.toml content to it, I wasn't able to pip install it anymore. I was worried for a minute there, until I worked it out.

I wouldn't want new users running into the same problem and concluding that it's not a good fit for their project. 

I think the proposed change is a good default because setuptools and wheel are so commonly used. I can't think of a case where having them included could cause a problem. But of course, please feel free to close this PR if you feel it doesn't serve the majority of your users..
