### PR TITLE
Add new attribute 'supported' in pyproject.toml

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -53,21 +53,15 @@ requires = [
 
 # Mobile deployments
 [tool.briefcase.app.{{ cookiecutter.app_name }}.iOS]
-requires = [
 {%- if cookiecutter.gui_framework == 'Toga' %}
-    'toga-iOS>=0.3.0.dev20',
-{% endif -%}
-]
-{%- if cookiecutter.gui_framework == 'PySide2' or cookiecutter.gui_framework == 'PursuedPyBear' %}
+requires = ['toga-iOS>=0.3.0.dev20']
+{%- else %}
 supported = false
 {%- endif %}
 
 [tool.briefcase.app.{{ cookiecutter.app_name }}.android]
-requires = [
 {%- if cookiecutter.gui_framework == 'Toga' %}
-    'toga-android>=0.3.0.dev20',
-{% endif -%}
-]
-{%- if cookiecutter.gui_framework == 'PySide2' or cookiecutter.gui_framework == 'PursuedPyBear' %}
+requires = ['toga-android>=0.3.0.dev20']
+{%- else %}
 supported = false
 {%- endif %}

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -58,6 +58,9 @@ requires = [
     'toga-iOS>=0.3.0.dev20',
 {% endif -%}
 ]
+{%- if cookiecutter.gui_framework == 'PySide2' or cookiecutter.gui_framework == 'PursuedPyBear' %}
+supported = false
+{%- endif %}
 
 [tool.briefcase.app.{{ cookiecutter.app_name }}.android]
 requires = [
@@ -65,3 +68,6 @@ requires = [
     'toga-android>=0.3.0.dev20',
 {% endif -%}
 ]
+{%- if cookiecutter.gui_framework == 'PySide2' or cookiecutter.gui_framework == 'PursuedPyBear' %}
+supported = false
+{%- endif %}


### PR DESCRIPTION
### Changes:
Add additional metadata attribute `supported = false` in the `pyproject.toml` for ios and android if the GUI framework is PySide2 or PPB.

Formattting of the toml file generated with Briefcase `new` command with Pyside2 selected:
![gui_pyside2](https://user-images.githubusercontent.com/65329090/102159865-56bf8600-3ebf-11eb-8ff8-08a93a6ee9e9.png)

Formattting of the toml file generated with Briefcase `new` command with Toga selected:
![gui_toga](https://user-images.githubusercontent.com/65329090/102160024-a1d99900-3ebf-11eb-9949-4115f3ee7ff1.png)

## Problem solved:
<!--- What problem does this change solve? -->
Ensures that the `pyproject.toml` file generated from this template using the briefcase `new` command will contain a flag to disallow creation of mobile apps with unsupported GUI through the briefcase `create` or `update` command. More details provided in the related issue below.


## Related issue:
Briefcase issue #539: [Provide better warnings when an app *can't* be deployed to mobile platforms](https://github.com/beeware/briefcase/issues/539)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
