### PR TITLE
Set WMCLASS for PySide2 and PursuedPyBear projects.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.X"
+        python-version: "3.7"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py37
 
 [testenv]
 skip_install = True

--- a/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/app.py
@@ -37,11 +37,6 @@ except ImportError:
 
 from PySide2 import QtWidgets
 
-# Find the name of the module that was used to start the app
-app_module = sys.modules['__main__'].__package__
-# Retrieve the app's metadata
-metadata = importlib_metadata.metadata(app_module)
-
 
 class {{ cookiecutter.class_name }}(QtWidgets.QMainWindow):
     def __init__(self):
@@ -52,14 +47,22 @@ class {{ cookiecutter.class_name }}(QtWidgets.QMainWindow):
         self.setWindowTitle('{{ cookiecutter.app_name }}')
         self.show()
 
+
 def main():
     # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. Desktop file of this app will include
+    # to their application menus. The .desktop file of this app will include
     # StartupWMClass key, set to app's formal name, which helps associate
     # app's windows to its menu item.
+    #
     # For association to work any windows of the app must have WMCLASS
     # property set to match the value set in app's desktop file. For PySide2
     # this is set with setApplicationName().
+
+    # Find the name of the module that was used to start the app
+    app_module = sys.modules['__main__'].__package__
+    # Retrieve the app's metadata
+    metadata = importlib_metadata.metadata(app_module)
+
     QtWidgets.QApplication.setApplicationName(metadata['Formal-Name'])
 
     app = QtWidgets.QApplication(sys.argv)
@@ -77,11 +80,6 @@ except ImportError:
 
 import ppb
 
-# Find the name of the module that was used to start the app
-app_module = sys.modules['__main__'].__package__
-# Retrieve the app's metadata
-metadata = importlib_metadata.metadata(app_module)
-
 
 class {{ cookiecutter.class_name }}(ppb.BaseScene):
     def __init__(self, **props):
@@ -94,12 +92,19 @@ class {{ cookiecutter.class_name }}(ppb.BaseScene):
 
 def main():
     # Linux desktop environments use app's .desktop file to integrate the app
-    # to their application menus. Desktop file of this app will include
+    # to their application menus. The .desktop file of this app will include
     # StartupWMClass key, set to app's formal name, which helps associate
     # app's windows to its menu item.
+    #
     # For association to work any windows of the app must have WMCLASS
     # property set to match the value set in app's desktop file. For PPB this
     # is set using environment variable.
+
+    # Find the name of the module that was used to start the app
+    app_module = sys.modules['__main__'].__package__
+    # Retrieve the app's metadata
+    metadata = importlib_metadata.metadata(app_module)
+
     os.environ['SDL_VIDEO_X11_WMCLASS'] = metadata['Formal-Name']
 
     ppb.run(


### PR DESCRIPTION
Sets WMCLASS for PySide2 and PursuedPyBear projects. Toga project appears already to set WMCLASS properly and thus doesn't require any extra support.

Partially fixes https://github.com/beeware/briefcase/issues/661.

I tested on Linux with Python 3.10 with https://github.com/beeware/briefcase-linux-appimage-template/pull/10 that the each project creates, builds, installs and has its desktop file associated with app's window. 

Examples of WM_CLASS for each project type:

Toga:
```
$ xprop WM_CLASS
WM_CLASS(STRING) = "Hello World", "Hello World"
```

PySide2:
```
$ xprop WM_CLASS
WM_CLASS(STRING) = "__main__.py", "Hello World"
```

PursuedPyBear:
```
$ xprop WM_CLASS
WM_CLASS(STRING) = "Hello World", "Hello World"
```


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
