### PR TITLE
Add PySide6 template and PySide2 version bump

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,7 @@
     "gui_framework": [
         "Toga",
         "PySide2",
+        "PySide6",
         "None"
     ]
 }

--- a/{{ cookiecutter.app_name }}/setup.py
+++ b/{{ cookiecutter.app_name }}/setup.py
@@ -37,7 +37,8 @@ setup(
         'License :: OSI Approved :: {{ cookiecutter.license }}',
     ],
     install_requires=[{% if cookiecutter.gui_framework == 'PySide2' %}
-        'pyside2==5.13.0',{% endif %}
+        'pyside2==5.15.2',{% endif %}{% if cookiecutter.gui_framework == 'PySide6' %}
+        'pyside6==6.2.3',{% endif %}
     ],
     options={
         'app': {

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/__main__.py
@@ -3,7 +3,7 @@ from {{ cookiecutter.app_name }}.app import main
 if __name__ == '__main__':
 {%- if cookiecutter.gui_framework == 'Toga' %}
     main().main_loop()
-{%- elif cookiecutter.gui_framework == 'PySide2' %}
+{%- elif cookiecutter.gui_framework in ('PySide2', 'PySide6') %}
     main()
 {%- else %}
     main()

--- a/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}/app.py
@@ -26,8 +26,8 @@ class {{ app_class_name }}(toga.App):
 
 def main():
     return {{ app_class_name }}('{{ cookiecutter.formal_name }}', '{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}')
-{% elif cookiecutter.gui_framework == 'PySide2' %}import sys
-from PySide2 import QtWidgets
+{% elif cookiecutter.gui_framework in ('PySide2', 'PySide6') %}import sys
+from {{ cookiecutter.gui_framework }} import QtWidgets
 
 
 class {{ app_class_name }}(QtWidgets.QMainWindow):
@@ -42,8 +42,9 @@ class {{ app_class_name }}(QtWidgets.QMainWindow):
 def main():
     app = QtWidgets.QApplication(sys.argv)
     main_window = {{ app_class_name }}()
-    sys.exit(app.exec_())
-{% else -%}
+    {% if cookiecutter.gui_framework == 'PySide2' %}sys.exit(app.exec_())
+    {% else %}sys.exit(app.exec()){% endif %}
+{% else %}
 def main():
     # This should start and launch your app!
     pass


### PR DESCRIPTION
Added a template based on PySide2, to support PySide6

A version bump was included to use the latest PySide2 package, 5.15.2

As discussed in https://github.com/beeware/briefcase/issues/560 there is no option to generate a PySide6 based project.
Because the PySide2 is roughly the same, the same code was used but with two little changes:
- The import should state `PySide6` instead of `PySide2`
- The call to `exec_()` was changed to `exec()` because the previous was deprecated.

This change was motivated by the same discussion and another patch will be submitted to briefcase to include the option while using the `new` command.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

I didn't see any file that documented the available frameworks, so I didn't check the second box.

In case something else is missing or required, please let me know, I will be more than happy to adjust this PR.
