### PR TITLE
Replace 'linux.linuxdeploy' subsection with 'linux.appimage'

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -38,7 +38,7 @@ requires = [
 {% endif -%}
 ]
 
-[tool.briefcase.app.{{ cookiecutter.app_name }}.linux.linuxdeploy]
+[tool.briefcase.app.{{ cookiecutter.app_name }}.linux.appimage]
 system_requires = [
 {%- if cookiecutter.gui_framework == 'Toga' %}
     'gir1.2-webkit-3.0',


### PR DESCRIPTION
When the linux section was split in to two for building AppImage vs Flatpak, the section for AppImage was labeled linuxdeploy instead of appimage. Therefore, those settings were not referenced during briefcase execution for AppImage.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
