### PR TITLE
Use cookiecutter filter for escaping double quotes and backslashes beeware/briefcase#905

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.7"
+        python-version: "3.X"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -28,5 +28,8 @@
         "None"
     ],
     "template": "Not provided",
-    "branch": "Not provided"
+    "branch": "Not provided",
+    "_extensions": [
+        "briefcase.integrations.cookiecutter.TOMLEscape"
+    ]
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py37
 
 [testenv]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py37
 [testenv]
 skip_install = True
 deps =
+  git+https://github.com/beeware/briefcase.git
   cookiecutter
   flake8
   pytest

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -1,16 +1,16 @@
 # This project was generated using template: {{ cookiecutter.template }} and branch: {{ cookiecutter.branch }}
 [tool.briefcase]
-project_name = "{{ cookiecutter.project_name }}"
+project_name = "{{ cookiecutter.project_name|escape_toml }}"
 bundle = "{{ cookiecutter.bundle }}"
 version = "0.0.1"
 url = "{{ cookiecutter.url }}"
 license = "{{ cookiecutter.license }}"
-author = '{{ cookiecutter.author }}'
+author = "{{ cookiecutter.author }}"
 author_email = "{{ cookiecutter.author_email }}"
 
 [tool.briefcase.app.{{ cookiecutter.app_name }}]
-formal_name = "{{ cookiecutter.formal_name }}"
-description = "{{ cookiecutter.description }}"
+formal_name = "{{ cookiecutter.formal_name|escape_toml }}"
+description = "{{ cookiecutter.description|escape_toml }}"
 icon = "src/{{ cookiecutter.module_name }}/resources/{{ cookiecutter.app_name }}"
 sources = ['src/{{ cookiecutter.module_name }}']
 requires = [

--- a/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/app.py
@@ -1,5 +1,5 @@
 """
-{{ cookiecutter.description }}
+{{ cookiecutter.description|escape_toml }}
 """
 {% if cookiecutter.gui_framework == 'Toga' -%}
 import toga
@@ -113,7 +113,7 @@ def main():
 
     ppb.run(
         starting_scene={{ cookiecutter.class_name }},
-        title='{{ cookiecutter.formal_name }}',
+        title=metadata['Formal-Name'],
     )
 {% else -%}
 def main():


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Use the escape_toml tag to escape double quotes and backslashes in Formal Name and Description
<!--- What problem does this change solve? -->
`briefcase dev` doesn't fails anymore when double quotes and backslashes are used in Formal Name and Description
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
beeware/briefcase#905

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
