### PR TITLE
Update Toga projects to use webkit2.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create App
       run: |
         cd tests/apps
-        cat verify-${{ matrix.framework }}.config | briefcase new
+        cat verify-${{ matrix.framework }}.config | briefcase new --template ../../
     - name: Build App
       run: |
         cd tests/apps/verify-${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,8 @@ on:
       - master
 
 jobs:
-  build:
-
+  unit-tests:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -19,9 +17,109 @@ jobs:
         python-version: "3.X"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
         python -m pip install tox
     - name: Test with tox
       run: |
         tox
+
+  verify-apps:
+    name: Build apps
+    needs: unit-tests
+    strategy:
+      matrix:
+        os_name: ["macOS", "windows", "linux"]
+        framework: ["toga", "pyside2", "pyside6", "ppb"]
+        include:
+        - os_name: macOS
+          platform: macos-12
+          briefcase-data-dir: ~/Library/Caches/org.beeware.briefcase
+          pip-cache-dir: ~/Library/Caches/pip
+          docker-cache-dir: ~/Library/Containers/com.docker.docker/Data/vms/0/
+        - os_name: windows
+          platform: windows-latest
+          briefcase-data-dir: ~\AppData\Local\BeeWare\briefcase\Cache
+          pip-cache-dir: ~\AppData\Local\pip\Cache
+          docker-cache-dir: C:\ProgramData\DockerDesktop
+        - os_name: linux
+          # Need to use at least 22.04 to get the bugfix in flatpak for handling spaces in filenames.
+          platform: ubuntu-22.04
+          briefcase-data-dir: ~/.cache/briefcase
+          pip-cache-dir: ~/.cache/pip
+          # cache action cannot cache docker images (actions/cache#31)
+          # docker-cache-dir: /var/lib/docker
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Cache Briefcase tools
+      uses: actions/cache@v3.0.11
+      with:
+        key: briefcase-${{ matrix.platform }}
+        path: |
+          ~/.cookiecutters
+          ${{ matrix.briefcase-data-dir }}
+          ${{ matrix.pip-cache-dir }}
+          ${{ matrix.docker-cache-dir }}
+    - uses: actions/checkout@v3.1.0
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4.3.1
+      with:
+        python-version: "3.9"
+    - name: Install system dependencies
+      if: matrix.platform == 'ubuntu-22.04'
+      run: |
+        sudo apt-get install -y flatpak flatpak-builder
+    - name: Install Briefcase
+      run: python -m pip install git+https://github.com/beeware/briefcase.git
+    - name: Create App
+      run: |
+        cd tests/apps
+        cat verify-${{ matrix.framework }}.config | briefcase new
+    - name: Build App
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create
+        briefcase build
+        briefcase package --adhoc-sign
+    - name: Build Xcode project
+      if: matrix.os_name == 'macOS'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create ${{ matrix.os_name }} Xcode
+        briefcase build ${{ matrix.os_name }} Xcode
+        briefcase package ${{ matrix.os_name }} Xcode --adhoc-sign
+    - name: Build Visual Studio project
+      if: matrix.os_name == 'windows'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create ${{ matrix.os_name }} VisualStudio
+        briefcase build ${{ matrix.os_name }} VisualStudio
+        briefcase package ${{ matrix.os_name }} VisualStudio --adhoc-sign
+    - name: Build Flatpak project
+      if: matrix.os_name == 'linux' && matrix.framework == 'toga'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create ${{ matrix.os_name }} flatpak
+        briefcase build ${{ matrix.os_name }} flatpak
+        briefcase package ${{ matrix.os_name }} flatpak --adhoc-sign
+    - name: Build Android App
+      if: matrix.framework == 'toga'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create android
+        briefcase build android
+        briefcase package android --adhoc-sign
+    - name: Build iOS App
+      if: matrix.platform == 'macos-12' && matrix.framework == 'toga'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create iOS
+        briefcase build iOS
+        briefcase package iOS --adhoc-sign
+    - name: Build Web App
+      if: matrix.framework == 'toga'
+      run: |
+        cd tests/apps/verify-${{ matrix.framework }}
+        briefcase create web
+        briefcase build web
+        briefcase package web

--- a/tests/apps/verify-ppb.config
+++ b/tests/apps/verify-ppb.config
@@ -1,0 +1,10 @@
+Hello PPB
+verify-ppb
+org.beeware
+Hello PPB
+A PPB test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+4

--- a/tests/apps/verify-pyside2.config
+++ b/tests/apps/verify-pyside2.config
@@ -1,0 +1,10 @@
+Hello PySide2
+verify-pyside2
+org.beeware
+Hello PySide2
+A PySide2 test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+2

--- a/tests/apps/verify-pyside6.config
+++ b/tests/apps/verify-pyside6.config
@@ -1,0 +1,10 @@
+Hello PySide6
+verify-pyside6
+org.beeware
+Hello PySide6
+A PySide6 test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+3

--- a/tests/apps/verify-toga.config
+++ b/tests/apps/verify-toga.config
@@ -1,0 +1,10 @@
+Hello Toga
+verify-toga
+org.beeware
+Hello Toga
+A Toga test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+1

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -58,7 +58,7 @@ system_requires = [
     "libgtk-3-dev",
     "libpango1.0-dev",
     "librsvg2-dev",
-    "libwebkitgtk2-4.0-dev",
+    "libwebkit2gtk-4.0-dev",
 {% endif -%}
 ]
 linuxdeploy_plugins = [

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -58,7 +58,7 @@ system_requires = [
     "libgtk-3-dev",
     "libpango1.0-dev",
     "librsvg2-dev",
-    "libwebkitgtk2-4.0",
+    "libwebkitgtk2-4.0-dev",
 {% endif -%}
 ]
 linuxdeploy_plugins = [

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -52,13 +52,13 @@ requires = [
 [tool.briefcase.app.{{ cookiecutter.app_name }}.linux.appimage]
 system_requires = [
 {%- if cookiecutter.gui_framework == "Toga" %}
-    "gir1.2-webkit-3.0",
+    "gir1.2-webkit2-4.0",
     "libcairo2-dev",
     "libgirepository1.0-dev",
     "libgtk-3-dev",
     "libpango1.0-dev",
     "librsvg2-dev",
-    "libwebkitgtk-3.0-0",
+    "libwebkitgtk2-4.0",
 {% endif -%}
 ]
 linuxdeploy_plugins = [


### PR DESCRIPTION
The GTK Webkit libraries installed in Toga projects appear to be a hangover from the 16.04 days; the webkit libraries are still present on 18.04, but webkit2 gives a much better experience.

Refs beeware/briefcase#1029.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
