### PR TITLE
Remove Android test discovery workarounds

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -105,10 +105,6 @@ requires = [
 supported = false
 {%- endif %}
 
-build_gradle_extra_content = """
-android.defaultConfig.python.pyc.src false
-"""
-
 [tool.briefcase.app.{{ cookiecutter.app_name }}.web]
 {%- if cookiecutter.gui_framework == "Toga" %}
 requires = [

--- a/{{ cookiecutter.app_name }}/tests/{{ cookiecutter.module_name }}.py
+++ b/{{ cookiecutter.app_name }}/tests/{{ cookiecutter.module_name }}.py
@@ -1,6 +1,5 @@
 {%- if cookiecutter.test_framework == 'pytest' -%}
 import os
-import sys
 import tempfile
 from pathlib import Path
 
@@ -10,29 +9,6 @@ import pytest
 def run_tests():
     project_path = Path(__file__).parent.parent
     os.chdir(project_path)
-
-    ##################################################################
-    # WORKAROUND - On Android, we need to explicitly unpack the test
-    # source code into a location where it can be discovered.
-    ##################################################################
-    if hasattr(sys, "getandroidapilevel"):
-        import tests
-
-        def chaquopy_extract_package(pkg):
-            finder = pkg.__loader__.finder
-            for path in pkg.__path__:
-                chaquopy_extract_dir(finder, finder.zip_path(path))
-
-        def chaquopy_extract_dir(finder, zip_dir):
-            for filename in finder.listdir(zip_dir):
-                zip_path = f"{zip_dir}/{filename}"
-                if finder.isdir(zip_path):
-                    chaquopy_extract_dir(finder, zip_path)
-                else:
-                    finder.extract_if_changed(zip_path)
-        chaquopy_extract_package(tests)
-    ##################################################################
-
     returncode = pytest.main(
         [
             # Turn up verbosity
@@ -47,7 +23,6 @@ def run_tests():
     )
 {%- elif cookiecutter.test_framework == "unittest" -%}
 import os
-import sys
 import unittest
 from pathlib import Path
 
@@ -55,30 +30,6 @@ from pathlib import Path
 def run_tests():
     project_path = Path(__file__).parent.parent
     os.chdir(project_path)
-
-    ##################################################################
-    # WORKAROUND - On Android, we need to explicitly unpack the test
-    # source code into a location where it can be discovered.
-    ##################################################################
-    if hasattr(sys, "getandroidapilevel"):
-        import tests
-
-        def chaquopy_extract_package(pkg):
-            finder = pkg.__loader__.finder
-            for path in pkg.__path__:
-                chaquopy_extract_dir(finder, finder.zip_path(path))
-
-        def chaquopy_extract_dir(finder, zip_dir):
-            for filename in finder.listdir(zip_dir):
-                zip_path = f"{zip_dir}/{filename}"
-                if finder.isdir(zip_path):
-                    chaquopy_extract_dir(finder, zip_path)
-                else:
-                    finder.extract_if_changed(zip_path)
-
-        chaquopy_extract_package(tests)
-    ##################################################################
-
     loader = unittest.TestLoader()
     suite = loader.discover(project_path / "tests")
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
They're no longer needed now that `extractPackages` is in the Android template.

Requires https://github.com/beeware/briefcase-android-gradle-template/pull/60: DO NOT MERGE this PR before that one.

I've tested with pytest, but I can't see how to use unittest: it looks like the option was never added to Briefcase.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
