### PR TITLE
Use sys.argv to determine the tests to run.

### DIFF
--- a/{{ cookiecutter.app_name }}/tests/{{ cookiecutter.module_name }}.py
+++ b/{{ cookiecutter.app_name }}/tests/{{ cookiecutter.module_name }}.py
@@ -1,5 +1,6 @@
 {%- if cookiecutter.test_framework == 'pytest' -%}
 import os
+import sys
 import tempfile
 from pathlib import Path
 
@@ -9,6 +10,13 @@ import pytest
 def run_tests():
     project_path = Path(__file__).parent.parent
     os.chdir(project_path)
+
+    # Determine any args to pass to pytest. If there aren't any,
+    # default to running the whole test suite.
+    args = sys.argv[1:]
+    if len(args) == 0:
+        args = ["tests"]
+
     returncode = pytest.main(
         [
             # Turn up verbosity
@@ -18,8 +26,7 @@ def run_tests():
             # Overwrite the cache directory to somewhere writable
             "-o",
             f"cache_dir={tempfile.gettempdir()}/.pytest_cache",
-            project_path / "tests"
-        ]
+        ] + args
     )
 {%- elif cookiecutter.test_framework == "unittest" -%}
 import os


### PR DESCRIPTION
Adds support for arguments being provided at the command line in a pytest configuration. 

If no command line arguments are specified, the `tests` folder is executed; otherwise, all arguments are passed verbatim to pytest.

Support for unittest hasn't been implemented as it's not a straightforward argument manipulation.

Requires beeware/briefcase#1078.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
