### PR TITLE
Loosen version requirement for PySide6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   unit-tests:
@@ -23,104 +27,16 @@ jobs:
         tox
 
   verify-apps:
-    name: Build apps
+    name: Build App
     needs: unit-tests
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+    with:
+      python-version: "3.9"
+      briefcase-template-source: "../../"
+      runner-os: ${{ matrix.runner-os }}
+      framework: ${{ matrix.framework }}
     strategy:
+      fail-fast: false
       matrix:
-        os_name: ["macOS", "windows", "linux"]
-        framework: ["toga", "pyside2", "pyside6", "ppb"]
-        include:
-        - os_name: macOS
-          platform: macos-12
-          briefcase-data-dir: ~/Library/Caches/org.beeware.briefcase
-          pip-cache-dir: ~/Library/Caches/pip
-          docker-cache-dir: ~/Library/Containers/com.docker.docker/Data/vms/0/
-        - os_name: windows
-          platform: windows-latest
-          briefcase-data-dir: ~\AppData\Local\BeeWare\briefcase\Cache
-          pip-cache-dir: ~\AppData\Local\pip\Cache
-          docker-cache-dir: C:\ProgramData\DockerDesktop
-        - os_name: linux
-          # Need to use at least 22.04 to get the bugfix in flatpak for handling spaces in filenames.
-          platform: ubuntu-22.04
-          briefcase-data-dir: ~/.cache/briefcase
-          pip-cache-dir: ~/.cache/pip
-          # cache action cannot cache docker images (actions/cache#31)
-          # docker-cache-dir: /var/lib/docker
-    runs-on: ${{ matrix.platform }}
-    steps:
-    - name: Cache Briefcase tools
-      uses: actions/cache@v3.2.5
-      with:
-        key: briefcase-${{ matrix.platform }}
-        path: |
-          ~/.cookiecutters
-          ${{ matrix.briefcase-data-dir }}
-          ${{ matrix.pip-cache-dir }}
-          ${{ matrix.docker-cache-dir }}
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
-    - name: Install system dependencies
-      if: matrix.platform == 'ubuntu-22.04'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y flatpak flatpak-builder
-    - name: Install Briefcase
-      run: python -m pip install git+https://github.com/beeware/briefcase.git
-    - name: Create App
-      run: |
-        cd tests/apps
-        cat verify-${{ matrix.framework }}.config | briefcase new --template ../../
-    - name: Build App
-      run: |
-        cd tests/apps/verify-${{ matrix.framework }}
-        briefcase create
-        briefcase build
-        briefcase package --adhoc-sign
-    - name: Build Xcode project
-      if: matrix.os_name == 'macOS'
-      run: |
-        cd tests/apps/verify-${{ matrix.framework }}
-        briefcase create ${{ matrix.os_name }} Xcode
-        briefcase build ${{ matrix.os_name }} Xcode
-        briefcase package ${{ matrix.os_name }} Xcode --adhoc-sign
-    - name: Build Visual Studio project
-      if: matrix.os_name == 'windows'
-      run: |
-        cd tests/apps/verify-${{ matrix.framework }}
-        briefcase create ${{ matrix.os_name }} VisualStudio
-        briefcase build ${{ matrix.os_name }} VisualStudio
-        briefcase package ${{ matrix.os_name }} VisualStudio --adhoc-sign
-    - name: Build Flatpak project
-      if: matrix.os_name == 'linux' && matrix.framework == 'toga'
-      run: |
-        cd tests/apps/verify-${{ matrix.framework }}
-        briefcase create ${{ matrix.os_name }} flatpak
-        briefcase build ${{ matrix.os_name }} flatpak
-        briefcase package ${{ matrix.os_name }} flatpak --adhoc-sign
-    - name: Build Android App
-      if: matrix.framework == 'toga'
-      run: |
-        cd tests/apps/verify-${{ matrix.framework }}
-        briefcase create android
-        briefcase build android
-        briefcase package android --adhoc-sign
-    - name: Build iOS App
-      if: matrix.platform == 'macos-12' && matrix.framework == 'toga'
-      run: |
-        cd tests/apps/verify-${{ matrix.framework }}
-        briefcase create iOS
-        briefcase build iOS
-        briefcase package iOS --adhoc-sign
-    - name: Build Web App
-      if: matrix.framework == 'toga'
-      run: |
-        cd tests/apps/verify-${{ matrix.framework }}
-        briefcase create web
-        briefcase build web
-        briefcase package web
+        framework: [ "toga", "pyside2", "pyside6", "ppb" ]
+        runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .python-version
 .vscode
+.idea
 __pycache__

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -23,7 +23,7 @@ requires = [
 {%- if cookiecutter.gui_framework == "PySide2" %}
     "pyside2~=5.15.2",
 {%- elif cookiecutter.gui_framework == "PySide6" %}
-    "pyside6~=6.2.4",
+    "pyside6~=6.2",
 {%- elif cookiecutter.gui_framework == "PursuedPyBear" %}
     "ppb~=1.1",
 {%- endif %}


### PR DESCRIPTION
## Changes
The PySide6 requirement of `~=6.2.4` is too strict since it only allows `pip` to install versions of PySide6 that match `6.2.*`. The intention is to allow installing `6.2.4` on certain platforms (notably Ubuntu 1804) while allowing the most recent to be installed where possible.

Using `PySide6~=6.2` achieves this. It would probably be ideal if we could tell `pip` "install the latest version `6.4.*` if any of them are supported or just install `6.2.4`"....but I couldn't figure out a way to do this.

## Dependent PRs
- beeware/.github#12
- beeware/.github#13

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
