### PR TITLE
Tweak the system python version definition in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,12 @@ jobs:
     needs: unit-tests
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
-      python-version: "3.9"
+      # This *must* be the version of Python that is the native system Python on
+      # ubuntu-22.04, which is needed to test local Debian packages. We use
+      # ubuntu-22.04 explicitly rather than ubuntu-latest because when
+      # ubuntu-latest upgrades to ubuntu-24.04, it will happen gradually, so the
+      # system Python version won't be predictable.
+      python-version: "3.10"
       briefcase-template-source: "../../"
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -39,4 +44,4 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside2", "pyside6", "ppb" ]
-        runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
+        runner-os: [ "macos-latest", "ubuntu-22.04", "windows-latest" ]


### PR DESCRIPTION
In order to guarantee local system python builds, we need to be explicit about the Python version and the Ubuntu image.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
