### PR TITLE
Bump kde to 6.4 and gnome to 44

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -186,11 +186,11 @@ linuxdeploy_plugins = [
 [tool.briefcase.app.{{ cookiecutter.app_name }}.linux.flatpak]
 {%- if cookiecutter.gui_framework == "Toga" %}
 flatpak_runtime = "org.gnome.Platform"
-flatpak_runtime_version = "42"
+flatpak_runtime_version = "44"
 flatpak_sdk = "org.gnome.Sdk"
 {%- elif cookiecutter.gui_framework in ["PySide2", "PySide6"] %}
 flatpak_runtime = "org.kde.Platform"
-flatpak_runtime_version = "6.3"
+flatpak_runtime_version = "6.4"
 flatpak_sdk = "org.kde.Sdk"
 {%- endif %}
 


### PR DESCRIPTION
I noticed that Gnome 42 went EOL.

```
❯ flatpak update org.gnome.Platform
Looking for updates…
Info: (pinned) org.gnome.Platform//42 is end-of-life, with reason:
   The GNOME 42 runtime is no longer supported as of March 21, 2023. Please ask your application developer to migrate to a supported platform.
```

Gnome 44 did just come out but this worked out of the box for me with toga as well as pyside6.

I tested this using the pending standalone Python work....so, we should probably wait until those land.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
