### PR TITLE
Default the Flatpak runtime to Freedesktop if not using Toga or PySide

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -219,6 +219,10 @@ flatpak_sdk = "org.gnome.Sdk"
 flatpak_runtime = "org.kde.Platform"
 flatpak_runtime_version = "6.4"
 flatpak_sdk = "org.kde.Sdk"
+{%- else %}
+flatpak_runtime = "org.freedesktop.Platform"
+flatpak_runtime_version = "22.08"
+flatpak_sdk = "org.freedesktop.Sdk"
 {%- endif %}
 
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.windows]


### PR DESCRIPTION
## Changes
- Instead of the Flatpak runtime defaulting to Freedesktop when Briefcase builds the Flatpak, the default is now locked in when the project is created.
- Dependent on beeware/briefcase#1272

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase
BRIEFCASE_REF: flatpak-freedesktop-platform-update

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
