### PR TITLE
Remove reference to webkit in AppImage configuration.

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -194,8 +194,6 @@ system_requires = [
     "libcanberra-gtk3",
     "PackageKit-gtk3-module",
     "gvfs-client",
-    # Needed to provide WebKit2 at runtime
-    # "webkit2gtk3",
 {%- elif cookiecutter.gui_framework == "PySide2" %}
 # ?? FIXME
 {%- elif cookiecutter.gui_framework == "PySide6" %}


### PR DESCRIPTION
Removes the reference to Webkit2 in the AppImage configuration, since it won't ever work.

Refs beeware/briefcase#1322

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
