### PR TITLE
Rename template info key names in cookiecutter context

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -33,8 +33,8 @@
         "unittest"
     ],
     "briefcase_version": "Unknown",
-    "template": "Not provided",
-    "branch": "Not provided",
+    "template_source": "Not provided",
+    "template_branch": "Not provided",
     "_extensions": [
         "briefcase.integrations.cookiecutter.TOMLEscape"
     ]

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -1,4 +1,4 @@
-# This project was generated with {{ cookiecutter.briefcase_version }} using template: {{ cookiecutter.template }}@{{ cookiecutter.branch }}
+# This project was generated with {{ cookiecutter.briefcase_version }} using template: {{ cookiecutter.template_source }}@{{ cookiecutter.template_branch }}
 [tool.briefcase]
 project_name = "{{ cookiecutter.project_name|escape_toml }}"
 bundle = "{{ cookiecutter.bundle }}"


### PR DESCRIPTION
- In cookiecutter>=2.2.0, the template key in context has special meaning for nested templates and must be renamed.
- RE: beeware/briefcase#1348

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase
BRIEFCASE_REF: cookiecutter-template-fix

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
