### PR TITLE
using pyside-essentials instead fo full package

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -181,7 +181,11 @@ system_runtime_requires = [
 ]
 
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.appimage]
+{%- if cookiecutter.gui_framework == "PySide6" %}
+manylinux = "manylinux_2_28"
+{%- else %}
 manylinux = "manylinux2014"
+{%- endif %}
 
 system_requires = [
 {%- if cookiecutter.gui_framework == "Toga" %}

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -25,7 +25,8 @@ requires = [
 {%- if cookiecutter.gui_framework == "PySide2" %}
     "pyside2~=5.15.2",
 {%- elif cookiecutter.gui_framework == "PySide6" %}
-    "pyside6~=6.2",
+    "PySide6-Essentials~=6.5",
+    # "PySide6-Addons~=6.5",
 {%- elif cookiecutter.gui_framework == "PursuedPyBear" %}
     "ppb~=1.1",
 {%- elif cookiecutter.gui_framework == "Pygame" %}


### PR DESCRIPTION
Replaced in Cookiecutter template for PySide6 the full package with essentials only
Will speed up installation.
.
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] All new features have been tested
- [ x] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
