### PR TITLE
Enable universal builds by default on new macOS projects.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,8 @@ jobs:
       matrix:
         framework: [ "toga", "pyside2", "pyside6", "ppb", "pygame" ]
         runner-os: [ "macos-latest", "ubuntu-22.04", "windows-latest" ]
+        exclude:
+          # PySide2 doesn't publish *any* universal or ARM64 wheels, and is unlikely to
+          # ever do so, so we can't test pyside2 on macOS
+          - runner-os: "macos-latest"
+            framework: "pyside2"

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -40,6 +40,7 @@ test_requires = [
 ]
 
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.macOS]
+universal_build = true
 requires = [
 {%- if cookiecutter.gui_framework == "Toga" %}
     "toga-cocoa~=0.3.1",


### PR DESCRIPTION
Adds a `universal_build` descriptor to new macOS projects. 

Disables Pyside2 builds on macOS due to a lack of ARM64 wheels. Ideally, we'd use this as an opportunity to test single-platform builds, but we can't do that without having a command line option to override project settings (i.e. beeware/briefcase#1115).

Refs beeware/briefcase#1482
Refs beeware/briefcase#1492

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
