### PR TITLE
Default to manylinux_2_28 for appimage builds.

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -214,11 +214,7 @@ system_runtime_requires = [
 ]
 
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.appimage]
-{%- if cookiecutter.gui_framework == "PySide6" %}
 manylinux = "manylinux_2_28"
-{%- else %}
-manylinux = "manylinux2014"
-{%- endif %}
 
 system_requires = [
 {%- if cookiecutter.gui_framework == "Toga" %}


### PR DESCRIPTION
As the Python-build-standalone support packages now depend on a recent clang, update the default template to use manylinux_2_28 for all builds.

Refs beeware/briefcase#1500
Refs beeware/briefcase-linux-appimage-template#38

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
