### PR TITLE
Loosen version constraints for frameworks

### DIFF
--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -23,14 +23,14 @@ test_sources = [
 
 requires = [
 {%- if cookiecutter.gui_framework == "PySide2" %}
-    "pyside2~=5.15.2",
+    "pyside2~=5.15",
 {%- elif cookiecutter.gui_framework == "PySide6" %}
     "PySide6-Essentials~=6.5",
     # "PySide6-Addons~=6.5",
 {%- elif cookiecutter.gui_framework == "PursuedPyBear" %}
     "ppb~=1.1",
 {%- elif cookiecutter.gui_framework == "Pygame" %}
-    "pygame~=2.2.0"
+    "pygame~=2.2",
 {%- endif %}
 ]
 test_requires = [


### PR DESCRIPTION
`pygame~=2.2.0` is unnecessarily strict AFAICT....especially since 2.5.2 is the current version.

Also loosened PySide2 version but I don't think that matters practically speaking since there don't seem to be many releases.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
