### PR TITLE
Bump black-pre-commit-mirror from 23.11.0 to 23.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: docformatter
         args: [--in-place, --black]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
+    rev: 23.12.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 23.11.0 to 23.12.0 and ran the update against the repo.