### PR TITLE
Support cookiecutter v2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 black == 24.3.0
-# briefcase @ git+https://github.com/beeware/briefcase.git
-briefcase @ git+https://github.com/rmartin16/briefcase.git@template-whitespace
+briefcase @ git+https://github.com/beeware/briefcase.git
 flake8 == 7.0.0
 pre-commit == 3.7.0
 pytest == 8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 black == 24.3.0
-briefcase @ git+https://github.com/beeware/briefcase.git
+# briefcase @ git+https://github.com/beeware/briefcase.git
+briefcase @ git+https://github.com/rmartin16/briefcase.git@template-whitespace
 flake8 == 7.0.0
 pre-commit == 3.7.0
 pytest == 8.1.1

--- a/tests/test_app_template.py
+++ b/tests/test_app_template.py
@@ -25,7 +25,7 @@ BASIC_APP_CONTEXT = {
     "test_framework": "pytest",
 }
 
-SIMPLE_TABLE_CONTENT = """
+SIMPLE_TABLE_CONTENT = """\
 requires = [
     "{}==1.1.0",
 ]
@@ -201,12 +201,12 @@ field = "pyproject_table_briefcase_extra_content"
 answer = 42
 """,
                 pyproject_table_briefcase_app_extra_content="""
-
 other_resources = [
     "dir",
     "otherdir",
     "pyproject_table_briefcase_app_extra_content",
-]""",
+]
+""",
                 pyproject_table_macOS=SIMPLE_TABLE_CONTENT.format("macOS"),
                 pyproject_table_linux=SIMPLE_TABLE_CONTENT.format("linux"),
                 pyproject_table_linux_appimage=SIMPLE_TABLE_CONTENT.format("appimage"),
@@ -214,7 +214,7 @@ other_resources = [
                 pyproject_table_windows=SIMPLE_TABLE_CONTENT.format("windows"),
                 pyproject_table_iOS=SIMPLE_TABLE_CONTENT.format("iOS"),
                 pyproject_table_android=SIMPLE_TABLE_CONTENT.format("android"),
-                pyproject_extra_content="""
+                pyproject_extra_content="""\
 [tool.briefcase.{{ cookiecutter.app_name|escape_non_ascii }}.my_custom_format_one]
 field = "pyproject_extra_content"
 
@@ -241,6 +241,7 @@ url = "https://example.com"
 license = "BSD license"
 author = "Jane Developer"
 author_email = "jane@example.com"
+
 field = "pyproject_table_briefcase_extra_content"
 answer = 42
 
@@ -318,16 +319,17 @@ list = [
             **dict(
                 app_source=APP_SOURCE,
                 app_start_source=APP_START_SOURCE,
-                pyproject_table_briefcase_extra_content='\nfield = "pyproject_table_briefcase_extra_content"',
+                pyproject_table_briefcase_extra_content='field = "pyproject_table_briefcase_extra_content"\n',
                 pyproject_table_briefcase_app_extra_content="""
 other_resources = ["dir", "pyproject_table_briefcase_app_extra_content"]
 """,
-                pyproject_extra_content="""
+                pyproject_extra_content="""\
 [tool.briefcase.{{ cookiecutter.app_name|escape_non_ascii }}.my_custom_format_one]
 field = "pyproject_extra_content_one"
 
 [tool.briefcase.{{ cookiecutter.app_name|escape_non_ascii }}.my_custom_format_two]
 field = "pyproject_extra_content_two"
+
 """,
                 briefcase_version="v0.3.16-3",
                 template_source="https://example.com/beeware/briefcase-template",
@@ -358,6 +360,7 @@ sources = [
 test_sources = [
     "tests",
 ]
+
 other_resources = ["dir", "pyproject_table_briefcase_app_extra_content"]
 
 [tool.briefcase.helloworld.my_custom_format_one]
@@ -365,6 +368,7 @@ field = "pyproject_extra_content_one"
 
 [tool.briefcase.helloworld.my_custom_format_two]
 field = "pyproject_extra_content_two"
+
 ''',
         id="only-extra-content",
     ),
@@ -400,9 +404,8 @@ def test_parse_pyproject_toml(app_directory, context, expected_toml):
     """Test for errors in parsing the generated pyproject.toml file."""
     pyproject_toml = app_directory / "helloworld" / "pyproject.toml"
     assert pyproject_toml.is_file()  # check pyproject.toml exists
-    toml.load(pyproject_toml)  # any error in parsing will trigger pytest
-    with open(pyproject_toml) as toml_file:
-        assert expected_toml == toml_file.read()
+    toml.load(pyproject_toml)  # any error in parsing will trigger pytest failure
+    assert expected_toml == pyproject_toml.read_text()
 
 
 @pytest.mark.parametrize("context, expected_toml", TEST_CASES)

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -7,8 +7,7 @@ url = "{{ cookiecutter.url }}"
 license = "{{ cookiecutter.license }}"
 author = "{{ cookiecutter.author }}"
 author_email = "{{ cookiecutter.author_email }}"
-{{- cookiecutter.pyproject_table_briefcase_extra_content }}
-
+{{ cookiecutter.pyproject_table_briefcase_extra_content }}
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}]
 formal_name = "{{ cookiecutter.formal_name|escape_toml }}"
 description = "{{ cookiecutter.description|escape_toml }}"
@@ -21,69 +20,57 @@ sources = [
 test_sources = [
     "tests",
 ]
-{{- cookiecutter.pyproject_table_briefcase_app_extra_content }}
+{{ cookiecutter.pyproject_table_briefcase_app_extra_content }}
 {% if cookiecutter.pyproject_table_macOS %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.macOS]
-{{- cookiecutter.pyproject_table_macOS }}
+{{ cookiecutter.pyproject_table_macOS }}
 {% endif %}
 {% if cookiecutter.pyproject_table_linux %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux]
-{{- cookiecutter.pyproject_table_linux }}
+{{ cookiecutter.pyproject_table_linux }}
 {% endif %}
 {% if cookiecutter.pyproject_table_linux_system_debian %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.system.debian]
-{{- cookiecutter.pyproject_table_linux_system_debian }}
+{{ cookiecutter.pyproject_table_linux_system_debian }}
 {% endif %}
 {% if cookiecutter.pyproject_table_linux_system_rhel %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.system.rhel]
-{{- cookiecutter.pyproject_table_linux_system_rhel }}
+{{ cookiecutter.pyproject_table_linux_system_rhel }}
 {% endif %}
 {% if cookiecutter.pyproject_table_linux_system_suse %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.system.suse]
-{{- cookiecutter.pyproject_table_linux_system_suse }}
+{{ cookiecutter.pyproject_table_linux_system_suse }}
 {% endif %}
 {% if cookiecutter.pyproject_table_linux_system_arch %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.system.arch]
-{{- cookiecutter.pyproject_table_linux_system_arch }}
+{{ cookiecutter.pyproject_table_linux_system_arch }}
 {% endif %}
 {% if cookiecutter.pyproject_table_linux_appimage %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.appimage]
-{{- cookiecutter.pyproject_table_linux_appimage }}
+{{ cookiecutter.pyproject_table_linux_appimage }}
 {% endif %}
 {% if cookiecutter.pyproject_table_linux_flatpak %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.linux.flatpak]
-{{- cookiecutter.pyproject_table_linux_flatpak }}
+{{ cookiecutter.pyproject_table_linux_flatpak }}
 {% endif %}
 {% if cookiecutter.pyproject_table_windows %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.windows]
-{{- cookiecutter.pyproject_table_windows }}
+{{ cookiecutter.pyproject_table_windows }}
 {% endif %}
 {% if cookiecutter.pyproject_table_iOS or cookiecutter.pyproject_table_android %}
-
 # Mobile deployments
 {% endif %}
 {% if cookiecutter.pyproject_table_iOS %}
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.iOS]
-{{- cookiecutter.pyproject_table_iOS }}
+{{ cookiecutter.pyproject_table_iOS }}
 {% endif %}
 {% if cookiecutter.pyproject_table_android %}
-
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.android]
-{{- cookiecutter.pyproject_table_android }}
+{{ cookiecutter.pyproject_table_android }}
 {% endif %}
 {% if cookiecutter.pyproject_table_web %}
-
 # Web deployments
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}.web]
-{{- cookiecutter.pyproject_table_web }}
+{{ cookiecutter.pyproject_table_web }}
 {% endif %}
-{{ cookiecutter.pyproject_extra_content }}
+{{ cookiecutter.pyproject_extra_content -}}

--- a/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/__main__.py
+++ b/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/__main__.py
@@ -1,5 +1,5 @@
 {% if cookiecutter.app_start_source %}
-{{ cookiecutter.app_start_source }}
+{{ cookiecutter.app_start_source -}}
 {% else %}
 from {{ cookiecutter.module_name }}.app import main
 

--- a/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/app.py
+++ b/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/app.py
@@ -3,7 +3,7 @@
 """
 
 {% if cookiecutter.app_source %}
-{{ cookiecutter.app_source }}
+{{ cookiecutter.app_source -}}
 {% else %}
 
 def main():


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/briefcase/pull/1724
- v2.6.0 changed how jinja2 whitespace control configuration is respected; these changes ensure the rolled out project is the same.

## Notes
- This should be merged in tandem with https://github.com/beeware/briefcase/pull/1724

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase
BRIEFCASE_REF: template-whitespace

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
