### PR TITLE
Add hidden `.briefcase` directory to `.gitignore`

### DIFF
--- a/{{ cookiecutter.app_name }}/.gitignore
+++ b/{{ cookiecutter.app_name }}/.gitignore
@@ -58,5 +58,6 @@ var/
 ## mpeltonen/sbt-idea plugin
 .idea_modules/
 
-# Briefcase log files
+# Briefcase files
 logs/
+.briefcase/


### PR DESCRIPTION
## Changes
- Adding new hidden `.briefcase` directory (added in https://github.com/beeware/briefcase/pull/1714) to `.gitignore` for new projects

## Notes
- Should we update `.gitignore` to align with GitHub's [default](https://github.com/github/gitignore/blob/main/Python.gitignore) for Python projects?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct