### PR TITLE
Issue1746 - Fixed the pyproject.toml template to toml_escape

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black == 24.4.2
 briefcase @ git+https://github.com/beeware/briefcase.git
 flake8 == 7.0.0
-pre-commit == 3.7.0
+pre-commit == 3.7.1
 pytest == 8.2.0
 toml == 0.10.2
 tox == 4.15.0

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -5,7 +5,7 @@ bundle = "{{ cookiecutter.bundle }}"
 version = "0.0.1"
 url = "{{ cookiecutter.url }}"
 license = "{{ cookiecutter.license }}"
-author = "{{ cookiecutter.author }}"
+author = "{{ cookiecutter.author|escape_toml }}"
 author_email = "{{ cookiecutter.author_email }}"
 {{ cookiecutter.pyproject_table_briefcase_extra_content }}
 [tool.briefcase.app.{{ cookiecutter.app_name|escape_non_ascii }}]


### PR DESCRIPTION
This is one part of the fix for pyproject.toml not escaping properly.  This applies a | toml_escape to the Author field.

Fixes 1746

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
