### PR TITLE
Bump codespell from v2.2.6 to v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: flake8
         args: [--max-line-length=119]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell
       additional_dependencies: [tomli]


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.2.6 to v2.3.0 and ran the update against the repo.