### PR TITLE
Bump flake8 from 7.1.0 to 7.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         args: [--max-line-length=119]


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 7.1.0 to 7.1.1 and ran the update against the repo.