### PR TITLE
Switch to explicit linux system handling.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
   verify-projects:
     name: Verify project
     needs: unit-tests
-    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
+    # TODO: Revert to main when .github#172 is merged
+    # uses: beeware/.github/.github/workflows/app-create-verify.yml@main
+    uses: beeware/.github/.github/workflows/app-create-verify.yml@599f2fbb61c17aa94a962f26647f31a879a31052
     with:
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -55,23 +57,28 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside6", "pygame" ]
-        runner-os: [ "macos-latest", "ubuntu-22.04", "windows-latest" ]
+        runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
 
   verify-apps:
     name: Build app
     needs: unit-tests
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+    # TODO: Revert to main when .github#172 is merged
+    # uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@599f2fbb61c17aa94a962f26647f31a879a31052
     with:
-      # This *must* be the version of Python that is the native system Python on
-      # ubuntu-22.04, which is needed to test local Debian packages. We use
-      # ubuntu-22.04 explicitly rather than ubuntu-latest because when
-      # ubuntu-latest upgrades to ubuntu-24.04, it will happen gradually, so the
-      # system Python version won't be predictable.
-      python-version: "3.10"
+      python-version: ${{ matrix.python-version }}
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
     strategy:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside6", "pygame" ]
-        runner-os: [ "macos-latest", "ubuntu-22.04", "windows-latest" ]
+        runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
+
+        include:
+          # A version of Python that is supported by all the GUI toolkits.
+          - python-version: "3.12"
+
+          # Ubuntu must always use the system Python
+          - runner-os: ubuntu-latest
+            python-version: system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
   verify-projects:
     name: Verify project
     needs: unit-tests
-    # TODO: Revert to main when .github#172 is merged
-    # uses: beeware/.github/.github/workflows/app-create-verify.yml@main
-    uses: beeware/.github/.github/workflows/app-create-verify.yml@599f2fbb61c17aa94a962f26647f31a879a31052
+    uses: beeware/.github/.github/workflows/app-create-verify.yml@main
     with:
       runner-os: ${{ matrix.runner-os }}
       framework: ${{ matrix.framework }}
@@ -62,9 +60,7 @@ jobs:
   verify-apps:
     name: Build app
     needs: unit-tests
-    # TODO: Revert to main when .github#172 is merged
-    # uses: beeware/.github/.github/workflows/app-build-verify.yml@main
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@599f2fbb61c17aa94a962f26647f31a879a31052
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       python-version: ${{ matrix.python-version }}
       runner-os: ${{ matrix.runner-os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ "toga", "pyside6", "pygame" ]
+        framework: [ "toga", "pyside6", "pygame", "console" ]
         runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
 
   verify-apps:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ "toga", "pyside6", "pygame" ]
+        framework: [ "toga", "pyside6", "pygame", "console" ]
         runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
 
         include:


### PR DESCRIPTION
beeware/.github#172 adds the ability to explicitly reference a "system" python, rather than pinning the Ubuntu release and ensuring the python-version matches the Ubuntu release.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
