### PR TITLE
Fix broken link URL in comments of pyproject.toml

### DIFF
--- a/tests/test_app_template.py
+++ b/tests/test_app_template.py
@@ -51,7 +51,7 @@ TEST_CASES = [
     pytest.param(
         BASIC_APP_CONTEXT,
         '''\
-# This project was generated with Unknown using template: Not provided/tree/Not provided
+# This project was generated with Unknown using template: Not provided @ Not provided
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"
@@ -101,7 +101,7 @@ test_sources = [
             ),
         },
         '''\
-# This project was generated with v0.3.16-2 using template: https://example.com/beeware/briefcase-template/tree/my-branch
+# This project was generated with v0.3.16-2 using template: https://example.com/beeware/briefcase-template @ my-branch
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"
@@ -230,7 +230,7 @@ list = [
             ),
         },
         '''\
-# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template/tree/my-branch
+# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template @ my-branch
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"
@@ -334,7 +334,7 @@ field = "pyproject_extra_content_two"
             ),
         },
         '''\
-# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template/tree/my-branch
+# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template @ my-branch
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"

--- a/tests/test_app_template.py
+++ b/tests/test_app_template.py
@@ -51,7 +51,7 @@ TEST_CASES = [
     pytest.param(
         BASIC_APP_CONTEXT,
         '''\
-# This project was generated with Unknown using template: Not provided@Not provided
+# This project was generated with Unknown using template: Not provided/tree/Not provided
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"
@@ -101,7 +101,7 @@ test_sources = [
             ),
         },
         '''\
-# This project was generated with v0.3.16-2 using template: https://example.com/beeware/briefcase-template@my-branch
+# This project was generated with v0.3.16-2 using template: https://example.com/beeware/briefcase-template/tree/my-branch
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"
@@ -185,7 +185,7 @@ requires = [
     "web==1.1.0",
 ]
 
-''',
+''',  # noqa: E501
         id="normal-context",
     ),
     pytest.param(
@@ -230,7 +230,7 @@ list = [
             ),
         },
         '''\
-# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template@my-branch
+# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template/tree/my-branch
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"
@@ -307,7 +307,7 @@ list = [
     "value",
     "value",
 ]
-''',
+''',  # noqa: E501
         id="normal-context-with-extra-content",
     ),
     pytest.param(
@@ -334,7 +334,7 @@ field = "pyproject_extra_content_two"
             ),
         },
         '''\
-# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template@my-branch
+# This project was generated with v0.3.16-3 using template: https://example.com/beeware/briefcase-template/tree/my-branch
 [tool.briefcase]
 project_name = "Project Awesome"
 bundle = "com.example"
@@ -365,7 +365,7 @@ field = "pyproject_extra_content_one"
 [tool.briefcase.helloworld.my_custom_format_two]
 field = "pyproject_extra_content_two"
 
-''',
+''',  # noqa: E501
         id="only-extra-content",
     ),
 ]

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -1,4 +1,4 @@
-# This project was generated with {{ cookiecutter.briefcase_version }} using template: {{ cookiecutter.template_source }}@{{ cookiecutter.template_branch }}
+# This project was generated with {{ cookiecutter.briefcase_version }} using template: {{ cookiecutter.template_source }}/tree/{{ cookiecutter.template_branch }}
 [tool.briefcase]
 project_name = "{{ cookiecutter.project_name|escape_toml }}"
 bundle = "{{ cookiecutter.bundle }}"

--- a/{{ cookiecutter.app_name }}/pyproject.toml
+++ b/{{ cookiecutter.app_name }}/pyproject.toml
@@ -1,4 +1,4 @@
-# This project was generated with {{ cookiecutter.briefcase_version }} using template: {{ cookiecutter.template_source }}/tree/{{ cookiecutter.template_branch }}
+# This project was generated with {{ cookiecutter.briefcase_version }} using template: {{ cookiecutter.template_source }} @ {{ cookiecutter.template_branch }}
 [tool.briefcase]
 project_name = "{{ cookiecutter.project_name|escape_toml }}"
 bundle = "{{ cookiecutter.bundle }}"


### PR DESCRIPTION
The first line of a new project's `pyproject.toml` contains a broken link URL.

Current:
> This project was generated with 0.3.22 using template:
https://github.com/beeware/briefcase-template@v0.3.22

Proposed:
> This project was generated with 0.3.22 using template:
https://github.com/beeware/briefcase-template/tree/v0.3.22

The removal of `@` and the addition of `/tree/` is required because when releasing, this repo does not create:
* https://github.com/beeware/briefcase-template/releases or
* https://github.com/beeware/briefcase-template/tags

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
