### PR TITLE
Add .briefcase to the default gitignore list

### DIFF
--- a/{{ cookiecutter.app_name }}/.gitignore
+++ b/{{ cookiecutter.app_name }}/.gitignore
@@ -60,3 +60,6 @@ var/
 
 # Briefcase log files
 logs/
+
+# Briefcase local configuratoin
+.briefcase/


### PR DESCRIPTION
With beeware/briefcase#2420 landing, and beeware/briefcase#2494 on the horizon, we should add `.briefcase` to the ignored directory list for new projects.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
