### PR TITLE
fix: extra space before author in LICENSE file

### DIFF
--- a/{{ cookiecutter.app_name }}/LICENSE
+++ b/{{ cookiecutter.app_name }}/LICENSE
@@ -63,7 +63,7 @@ limitations under the License.
 {% elif cookiecutter.license == 'GPL-2.0' %}
 
 {{ cookiecutter.formal_name }}: {{ cookiecutter.description }}
-Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author }}
+Copyright (C) {% now 'local', '%Y' %} {{ cookiecutter.author }}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of version 2 of the GNU General Public License as
@@ -79,7 +79,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {% elif cookiecutter.license == 'GPL-2.0+' %}
 
 {{ cookiecutter.formal_name }}: {{ cookiecutter.description }}
-Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author }}
+Copyright (C) {% now 'local', '%Y' %} {{ cookiecutter.author }}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -95,7 +95,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {% elif cookiecutter.license == 'GPL-3.0' %}
 {{ cookiecutter.formal_name }}: {{ cookiecutter.description }}
-Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author }}
+Copyright (C) {% now 'local', '%Y' %} {{ cookiecutter.author }}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of version 3 of the GNU General Public License as
@@ -110,7 +110,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {% elif cookiecutter.license == 'GPL-3.0+' %}
 {{ cookiecutter.formal_name }}: {{ cookiecutter.description }}
-Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author }}
+Copyright (C) {% now 'local', '%Y' %} {{ cookiecutter.author }}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -125,7 +125,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {% elif cookiecutter.license == 'Proprietary' %}
-Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author }}
+Copyright (C) {% now 'local', '%Y' %} {{ cookiecutter.author }}
 
 All rights reserved.
 {% endif %}


### PR DESCRIPTION
Removes an an extra space before the author name for certain licenses in the LICENSE file

## PR Checklist:

- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
