### PR TITLE
Migrate dependencies to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
-      pre-commit-source: --dependency-group dev
+      pre-commit-source: --group dev
 
   unit-tests:
     name: Unit tests
@@ -42,7 +42,7 @@ jobs:
       run: python -m pip install -U pip
 
     - name: Install Dependencies
-      run: python -m pip install --dependency-group test
+      run: python -m pip install --group test
 
     - name: Test with tox
       run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
-      pre-commit-source: -r requirements.txt
+      pre-commit-source: --dependency-group dev
 
   unit-tests:
     name: Unit tests
@@ -38,8 +38,11 @@ jobs:
       with:
         python-version: "3.X"
 
+    - name: Update pip
+      run: python -m pip install -U pip
+
     - name: Install Dependencies
-      run: python -m pip install -r requirements.txt
+      run: python -m pip install --dependency-group test
 
     - name: Test with tox
       run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: python -m pip install -U pip
 
     - name: Install Dependencies
-      run: python -m pip install --group test
+      run: python -m pip install --group dev
 
     - name: Test with tox
       run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[dependency-groups]
+test = [
+    "pytest == 9.0.3",
+    "toml == 0.10.2",
+    "flake8 == 7.3.0",
+    "briefcase @ git+https://github.com/beeware/briefcase.git",
+]
+dev = [
+    "tox == 4.54.0",
+    "pre-commit == 4.6.0",
+    "black == 26.5.1",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# Temporary: retained until beeware/.github's app-create-verify.yml
+# workflow is updated to read deps from pyproject.toml.
+# See beeware/briefcase-template#236.
+
 black == 26.5.1
 briefcase @ git+https://github.com/beeware/briefcase.git
 flake8 == 7.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 
 [testenv]
 skip_install = True
-deps = -r{toxinidir}/requirements.txt
+dependency_groups = test
 commands = python -m pytest {posargs:-vv --color yes tests/}


### PR DESCRIPTION
Move test and dev dependencies into PEP 735 dependency groups. Update tox.ini and ci.yml to install via --dependency-group.

requirements.txt retained as a stub until beeware/.github#355 lands; see #236 for context.

<!--- Describe your changes in detail -->
Migrate the repo's dependency declaration from `requirements.txt` to `pyproject.toml` using PEP 735 dependency groups (`test` and `dev`). Update `tox.ini` and `ci.yml` to install via `--dependency-group` instead of `-r requirements.txt`, including a pip upgrade step where needed for `--dependency-group` support.

`requirements.txt` is retained as a minimal stub because `app-create-verify.yml` in `beeware/.github` hardcodes a reference to it (see beeware/.github#355). A follow-up PR will remove it once that's resolved.

<!--- What problem does this change solve? -->
The repo was using `requirements.txt` for its test/dev dependencies. Moving to `pyproject.toml` consolidates dependency declarations into the modern standard location and enables more granular grouping (test vs dev) as requested in the issue.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs #236

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.7, Claude Code (Sonnet 4.6)
