### PR TITLE
Refactor dependency groups and scope CI installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
-      pre-commit-source: --group dev
+      pre-commit-source: --group pre-commit
 
   unit-tests:
     name: Unit tests
@@ -42,7 +42,7 @@ jobs:
       run: python -m pip install -U pip
 
     - name: Install Dependencies
-      run: python -m pip install --group dev
+      run: python -m pip install --group tox
 
     - name: Test with tox
       run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ test = [
     {include-group = "briefcase"},
 ]
 dev = [
-    "black == 26.5.1",
     {include-group = "briefcase"},
     {include-group = "pre-commit"},
     {include-group = "tox"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [dependency-groups]
 briefcase = [
-    "briefcase @ git+https://github.com/beeware/briefcase.git",  # provides cookiecutter
+    "briefcase @ git+https://github.com/beeware/briefcase",  # provides cookiecutter
 ]
 pre-commit = [
     "pre-commit == 4.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,23 @@
 [dependency-groups]
+briefcase = [
+    "briefcase @ git+https://github.com/beeware/briefcase.git",  # provides cookiecutter
+]
+pre-commit = [
+    "pre-commit == 4.6.0",
+]
+tox = [
+    "tox == 4.54.0",
+]
 test = [
     "pytest == 9.0.3",
     "toml == 0.10.2",
     "flake8 == 7.3.0",
-    "briefcase @ git+https://github.com/beeware/briefcase.git",
+    {include-group = "briefcase"},
 ]
 dev = [
-    "tox == 4.54.0",
-    "pre-commit == 4.6.0",
     "black == 26.5.1",
+    {include-group = "briefcase"},
+    {include-group = "pre-commit"},
+    {include-group = "tox"},
+    {include-group = "test"},
 ]


### PR DESCRIPTION
Refactors dependency groups in `pyproject.toml` to ensure that github workflow runs import the minimum amount of packages.


<!--- Describe your changes in detail -->
Groups have been updated to the following:
  - briefcase — provides cookiecutter; included by test and dev
  - pre-commit — used by the pre-commit CI job (--group pre-commit)
  - tox — used by the unit tests CI job (--group tox)
  - test — full test suite deps; includes briefcase
  - dev — local development convenience; includes all of the above

Afterwards, CI has been updated to use the new dependency groups.


<!--- What problem does this change solve? -->
This ensures that CI runs import dependency groups logically and do not overimport.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs #236 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I will abide by the BeeWare Code of Conduct
- [X] I have read and have followed the **CONTRIBUTING.md** file
- [X] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Sonnet 4.6
