### PR TITLE
Updated pyproject.toml to include CI group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,18 @@ pre-commit = [
 tox = [
     "tox == 4.54.0",
 ]
-test = [
-    "pytest == 9.0.3",
+verify = [
     "toml == 0.10.2",
     "flake8 == 7.3.0",
+]
+create-verify = [
+    "black == 25.1.0",
+    {include-group = "verify"},
+]
+test = [
+    "pytest == 9.0.3",
     {include-group = "briefcase"},
+    {include-group = "verify"},
 ]
 dev = [
     {include-group = "briefcase"},


### PR DESCRIPTION
Upstream CI check requires black, toml, and flake8. Exposing these in a create-verify group.
The two repositories are coupled already, so this addition does not cause too much regression.

beeware/.github's app-create-verify.yml workflow is being updated to read its dependencies directly from this repo's pyproject.toml via pip install --group, replacing the
requirements.txt shim. The create-verify group represents the exact surface that workflow invokes.

Refs https://github.com/beeware/.github/issues/355

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Sonnet 4.6
