### PR TITLE
Add cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,19 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
+        runner-os: [ "macos-15", "ubuntu-latest", "windows-latest" ]
 
   verify-apps:
     name: Build app
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        runner-os: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
+        runner-os: [ "macos-15", "ubuntu-latest", "windows-latest" ]
 
         include:
           # A version of Python that is supported by all the GUI toolkits.


### PR DESCRIPTION
Adds a 7-day cooldown to the GitHub Actions, pre-commit, and pip Dependabot update configurations. This delays newly published dependency versions before Dependabot proposes an update.

Fixes #268

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: ChatGPT