### PR TITLE
Remove resources/ folder from app template

### DIFF
--- a/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/resources/README
+++ b/{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/resources/README
@@ -1,2 +1,0 @@
-Put any application resources (e.g., icons and resources) here;
-they can be referenced in code as "resources/filename".


### PR DESCRIPTION
## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool


Follows up on **beeware/briefcase#3015**, where it was confirmed that the resources/README's guidance (referencing files as "resources/filename") only works for Toga apps, via `App.paths.app`. For Pygame, PySide6, and Console apps, which have no equivalent path-resolution mechanism, following this documented convention causes a `FileNotFoundError`, since `briefcase dev` runs the app with `cwd` set to the user's home directory rather than the project directory.

As suggested in the issue, this PR removes `{{ cookiecutter.app_name }}/src/{{ cookiecutter.module_name }}/resources/` (containing only the README) from the base template. 

Fixes beeware/briefcase#3015.

**Testing:**

Confirmed no other file in the template (tests, pyproject.toml, packaging config) references the resources/ folder.
Full template test suite passes: 12 passed via tox.